### PR TITLE
Remove redundant message from help

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ struct Arguments {
     #[structopt(long = "dump-events", help = "Dump events and exit .")] dump_events: bool,
     #[structopt(long = "columns", help = "Maximum number of columns.  Defaults to terminal width")]
     columns: Option<u16>,
-    #[structopt(short = "c", long = "colour", help = "Whether to enable colours (default auto)",
+    #[structopt(short = "c", long = "colour", help = "Whether to enable colours.",
                 default_value = "auto")]
     colour: Colour,
     #[structopt(help = "Input file.  If absent or - read from standard input")]


### PR DESCRIPTION
The auto-generated help already includes the default:

-c, --colour <colour>      Whether to enable colours (default auto) [default: auto]