### PR TITLE
Publicly expose the `TerminalWrite` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ use resources::Resource;
 
 // Expose some select things for use in main
 pub use resources::ResourceAccess;
-pub use terminal::Terminal;
+pub use terminal::{Terminal, TerminalWrite};
 pub use terminal::Size as TerminalSize;
 
 /// Dump markdown events to a writer.

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -106,6 +106,7 @@ pub enum AnsiStyle {
     DefaultForeground,
 }
 
+/// A trait to provide terminal escape code for any `Write` implementation
 pub trait TerminalWrite {
     /// Write a OSC `command`.
     fn write_osc(&mut self, command: &str) -> io::Result<()>;


### PR DESCRIPTION
It's visible in the `push_tty` function, and should thus
be exposed as well.

Maybe I am missing something, but that's the first minor bump I hit when trying to create my own implementation.