### PR TITLE
Use space after the header level_indicator to prevent crossing the first char

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,7 +516,7 @@ fn start_tag<'a, W: Write>(ctx: &mut Context<W>, tag: Tag<'a>) -> Result<(), Err
             let level_indicator = "\u{2504}".repeat(level as usize);
             ctx.enable_style(AnsiStyle::Bold)?;
             ctx.enable_style(AnsiStyle::Foreground(AnsiColour::Blue))?;
-            write!(ctx.output.writer, "{}", level_indicator)?
+            write!(ctx.output.writer, "{} ", level_indicator)?
         }
         BlockQuote => {
             ctx.block.indent_level += 4;


### PR DESCRIPTION
fixes #21

This is an alternative solution for the issue. Unlike the [previous fix](https://github.com/lunaryorn/mdcat/pull/24) that fixed it for only some fonts, an added space after the level indicator fixes the issue for _all_ fonts.

The downside is that this solution changes established visual style of this tool.