### PR TITLE
Add documentation in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ description = "cat for markdown: Show markdown documents in terminals"
 readme = "README.md"
 homepage = "https://github.com/lunaryorn/mdcat"
 repository = "https://github.com/lunaryorn/mdcat"
+documentation = "https://docs.rs/mdcat"
 keywords = ["markdown", "less"]
 version = "0.8.1-pre"
 categories = ["command-line-utilities", "text-processing"]


### PR DESCRIPTION
As this seems to be usable as a library as well, we should note the documentation location in the Cargo.toml file!

---

Just a quick drive-by patch :grinning: 