### PR TITLE
Add SVG support to Kitty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ To publish a new release run `scripts/release` from the project directory.
 ### Added
 - Release builds now perform full link-time optimization to create a smaller
   binary.  We do recommend to also `strip` the `mdcat` binary.
+- Render SVG images in [kitty] (see [GH-114])
 
 ### Changed
 - Replace `remote_resources` feature with `reqwest` feature to use reqwest for
   retrieving remote resources, and fall back to the `curl` command if `reqwest`
   is disabled.
+
+[GH-114]: https://github.com/lunaryorn/mdcat/pull/114
 
 ## [0.14.0] – 2019-12-18
 ### Added

--- a/README.md
+++ b/README.md
@@ -95,11 +95,12 @@ run `cargo install-update mdcat`.
 
 ### SVG support
 
-`mdcat` needs `rsvg-convert` to show SVG images in [iTerm2]; otherwise `mdcat`
-only shows the image title and URL for SVG images.  Install with `brew install
-librsvg`.
+`mdcat` needs `rsvg-convert` to show SVG images in [iTerm2] and [kitty];
+otherwise `mdcat` only shows the image title and URL for SVG images.  On macOS
+you can install the `librsvg` formula from Homebrew, on Linux the tool is
+typically part of the `librsvg-bin` package (or similar).
 
-[Terminology] supports SVG out of the box and needs no additional tools.
+[Terminology] renders SVG directly and needs no additional tools.
 
 ### Future plans
 

--- a/src/magic.rs
+++ b/src/magic.rs
@@ -19,6 +19,11 @@ use std::io::prelude::*;
 use std::io::{Error, ErrorKind};
 use std::process::*;
 
+/// Whether the given MIME type denotes an SVG image.
+pub fn is_svg(mime: &Mime) -> bool {
+    mime.type_() == mime::IMAGE && mime.subtype().as_str() == "svg"
+}
+
 /// Detect mime type with `file`.
 pub fn detect_mime_type(buffer: &[u8]) -> Result<Mime, failure::Error> {
     let mut process = Command::new("file")

--- a/src/terminal/iterm2.rs
+++ b/src/terminal/iterm2.rs
@@ -89,8 +89,7 @@ impl ITerm2Images {
     /// reading or rendering failed.
     pub fn read_and_render(&self, url: &Url) -> Result<Vec<u8>, Error> {
         let contents = read_url(&url)?;
-        let mime = magic::detect_mime_type(&contents)?;
-        if mime.type_() == mime::IMAGE && mime.subtype().as_str() == "svg" {
+        if magic::is_svg(&magic::detect_mime_type(&contents)?) {
             svg::render_svg(&contents).map_err(Into::into)
         } else {
             Ok(contents)

--- a/src/terminal/kitty.rs
+++ b/src/terminal/kitty.rs
@@ -20,6 +20,7 @@
 
 use crate::magic;
 use crate::resources::read_url;
+use crate::svg::render_svg;
 use failure::Error;
 use image::{ColorType, FilterType};
 use image::{DynamicImage, GenericImageView};
@@ -180,7 +181,12 @@ impl KittyImages {
     pub fn read_and_render(&self, url: &Url) -> Result<KittyImage, Error> {
         let contents = read_url(url)?;
         let mime = magic::detect_mime_type(&contents)?;
-        let image = image::load_from_memory(&contents)?;
+        let image = if magic::is_svg(&mime) {
+            let rendered = render_svg(&contents)?;
+            image::load_from_memory(&rendered)?
+        } else {
+            image::load_from_memory(&contents)?
+        };
         let terminal_size = get_terminal_size()?;
         let (image_width, image_height) = image.dimensions();
 


### PR DESCRIPTION
Render to PNG as we did for iTerm2, via rsvg-convert.

@fspillner Would appreciate a look :)