### PR TITLE
Fixed SIGPIPE when piping large data in magic

### DIFF
--- a/src/terminal/kitty.rs
+++ b/src/terminal/kitty.rs
@@ -232,15 +232,20 @@ impl KittyImages {
 
         let (image_width, image_height) = image.dimensions();
 
-        let image = if image_width > terminal_size.width || image_height > terminal_size.height {
-            image.resize_to_fill(
-                terminal_size.width,
-                terminal_size.height,
-                FilterType::Nearest,
-            )
-        } else {
-            image
-        };
+        let (image, image_width, image_height) =
+            if image_width > terminal_size.width || image_height > terminal_size.height {
+                (
+                    image.resize_to_fill(
+                        terminal_size.width,
+                        terminal_size.height,
+                        FilterType::Nearest,
+                    ),
+                    terminal_size.width,
+                    terminal_size.height,
+                )
+            } else {
+                (image, image_width, image_height)
+            };
 
         Ok(KittyImage {
             contents: match format {


### PR DESCRIPTION
Hey :-) 

Here a PR aiming to fix the issue #124.

The method `write_all` fail with "Broken pipe (os error 32)" when the data being piped is large enough to overflow the kernel pipe buffer and it terminates the process due to `SIGPIPE`. It seems, Rust suppresses that signal :-)

To workaround we extract only the first 4kb of interesting bytes that's sufficient for detecting the mime type.

I've tested and the large image is shown in Kitty, but in the meantime the resizing doesn't work as expected because the command `kitty +kitten icat --print-window-size` outputs strange window size `65535x65535` on my machine (Arch Linux). As kitty is not my primary terminal I don't want to have a deeper look.

Because I've done this feature initially and so I don't want to let this broken.

Fabian

**Update 2020-05-02:**

About the resizing I've identified the problem at fish shell that I'm using as default shell. After changing the default shell to bash the resizing works as expected.