### PR TITLE
Fix the image re-sizing in kitty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 To publish a new release run `scripts/release` from the project directory.
 
 ## [Unreleased]
+### Fixed
+- Fixed broken image scaling in [kitty] (see [GH-124] by [@fspillner]).
+
+[GH-124]: https://github.com/lunaryorn/mdcat/issues/124 
 
 ## [0.17.0] – 2020-05-20
 ### Changed

--- a/src/magic.rs
+++ b/src/magic.rs
@@ -16,6 +16,11 @@ pub fn is_svg(mime: &Mime) -> bool {
     mime.type_() == mime::IMAGE && mime.subtype().as_str() == "svg"
 }
 
+/// Whether the given MIME type denotes a PNG image.
+pub fn is_png(mime: &Mime) -> bool {
+    *mime == mime::IMAGE_PNG
+}
+
 /// Detect mime type with `file`.
 pub fn detect_mime_type(buffer: &[u8]) -> Result<Mime, Box<dyn std::error::Error>> {
     let mut process = Command::new("file")

--- a/src/terminal/kitty.rs
+++ b/src/terminal/kitty.rs
@@ -190,12 +190,9 @@ impl KittyImages {
             image::load_from_memory(&contents)
         }?;
         let terminal_size = get_terminal_size()?;
-        let (image_width, image_height) = image.dimensions();
 
-        let needs_scaledown =
-            image_width > terminal_size.width || image_height > terminal_size.height;
-
-        if mime.type_() == mime::IMAGE && mime.subtype().as_str() == "png" && !needs_scaledown {
+        if magic::is_png(&mime) && terminal_size.contains(&KittyDimension::from(image.dimensions()))
+        {
             self.render_as_png(contents)
         } else {
             self.render_as_rgb_or_rgba(image, terminal_size)
@@ -231,17 +228,17 @@ impl KittyImages {
             _ => KittyFormat::RGBA,
         };
 
-        let (image_width, image_height) = image.dimensions();
-
-        let image = if image_width > terminal_size.width || image_height > terminal_size.height {
-            image.resize_to_fill(
+        let image = if terminal_size.contains(&KittyDimension::from(image.dimensions())) {
+            image
+        } else {
+            image.resize(
                 terminal_size.width,
                 terminal_size.height,
                 FilterType::Nearest,
             )
-        } else {
-            image
         };
+
+        let image_dimension = KittyDimension::from(image.dimensions());
 
         Ok(KittyImage {
             contents: match format {
@@ -249,10 +246,7 @@ impl KittyImages {
                 _ => image.into_rgba().into_raw(),
             },
             format,
-            dimension: Some(KittyDimension {
-                width: image_width,
-                height: image_height,
-            }),
+            dimension: Some(image_dimension),
         })
     }
 }
@@ -289,4 +283,21 @@ impl KittyFormat {
 struct KittyDimension {
     width: u32,
     height: u32,
+}
+
+impl KittyDimension {
+    /// Check whether this dimension entirely contains the specified dimension.
+    fn contains(&self, other: &KittyDimension) -> bool {
+        self.width >= other.width && self.height >= other.height
+    }
+}
+
+impl From<(u32, u32)> for KittyDimension {
+    /// Convert a tuple struct (`u32`, `u32`) ordered by width and height
+    /// into a `KittyDimension`.
+    fn from(dimension: (u32, u32)) -> KittyDimension {
+        let (width, height) = dimension;
+
+        KittyDimension { width, height }
+    }
 }


### PR DESCRIPTION
Hey.

Here a separate PR for fixing the re-sizing bug in kitty terminal. The resulting image size from the resize must be used otherwise the image cannot be rendered in kitty.

Fabian