### PR TITLE
Fix SIGPIPE when piping large data in magic.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 To publish a new release run `scripts/release` from the project directory.
 
 ## [Unreleased]
+### Fixed
+- Fix SIGPIPE if rendering large image >1MB (see [GH-134]).
 
 ## [0.16.0] – 2020-04-11
 ### Changed

--- a/src/magic.rs
+++ b/src/magic.rs
@@ -19,6 +19,10 @@ use std::io::prelude::*;
 use std::io::{Error, ErrorKind};
 use std::process::*;
 
+/// The value of MAGIC_PARAM_BYTES_MAX borrowed from libmagic.
+/// See the man-page libmagic(3).
+const MAGIC_PARAM_BYTES_MAX: usize = 1_048_576;
+
 /// Whether the given MIME type denotes an SVG image.
 pub fn is_svg(mime: &Mime) -> bool {
     mime.type_() == mime::IMAGE && mime.subtype().as_str() == "svg"
@@ -39,7 +43,13 @@ pub fn detect_mime_type(buffer: &[u8]) -> Result<Mime, Box<dyn std::error::Error
         .stdin
         .as_mut()
         .expect("Forgot to pipe stdin?")
-        .write_all(buffer)?;
+        // extract only the first 1mb of interesting bytes; otherwise the
+        // method `write_all` fails with the "Broken pipe (os error 32)"
+        // error if the data being piped is large enough to be terminated
+        // due to signal SIGPIPE as the command file reads maximum
+        // 1048576 bytes from the input data.
+        // Check for MAGIC_PARAM_BYTES_MAX in the man-page of libmagic(3).
+        .write_all(&buffer[..std::cmp::min(buffer.len(), MAGIC_PARAM_BYTES_MAX)])?;
 
     let output = process.wait_with_output()?;
     if output.status.success() {
@@ -81,5 +91,23 @@ mod tests {
         let mime = result.unwrap();
         assert_eq!(mime.type_(), mime::IMAGE);
         assert_eq!(mime.subtype().as_str(), "svg");
+    }
+
+    #[test]
+    fn detect_mimetype_of_magic_param_bytes_max_length() {
+        let data = std::iter::repeat(b'\0')
+            .take(MAGIC_PARAM_BYTES_MAX)
+            .collect::<Vec<u8>>();
+        let result = detect_mime_type(&data);
+        assert!(result.is_ok(), "Unexpected error: {:?}", result);
+    }
+
+    #[test]
+    fn detect_mimetype_of_larger_than_magic_param_bytes_max_length() {
+        let data = std::iter::repeat(b'\0')
+            .take(MAGIC_PARAM_BYTES_MAX * 2)
+            .collect::<Vec<u8>>();
+        let result = detect_mime_type(&data);
+        assert!(result.is_ok(), "Unexpected error: {:?}", result);
     }
 }


### PR DESCRIPTION
Hi.

Here the second separate PR to fix the rendering of large image files, if the large image (>1MB) is piped through the file command in `src/magic.rs`: 

The method `write_all` fail with the error "Broken pipe (os error 32)", when the data being piped is large enough to be terminated due to SIGPIPE. To workaround, we just extract only the first 4kb of interesting bytes that's sufficient for determining the mime-type of the image.

I could reproduce the behavior in my fish shell:

    > cat sample/unicorn.png | file --brief --mime-type -
    image/png
    > echo $pipestatus
    0 0

and with a large image (>1MB):

    > cat sample/1mb.png | file --brief --mime-type -
    image/png
    > echo $pipestatus
    141 0

A `SIGPIPE` signal is sent by Kernel and the command is terminated with pipe status 141. My wild guess is that the command `file` closes the stdin after reading the 1MB bytes. I need more research on the topic around pipes.

WDYT? 
Fabian

**Update:**

Running `strace` on file command and found out that the command `file` stops reading the bytes at 1048576 bytes, here a extract from strace output:

    read(3, 0x7f40994dd010, 1048576)        = 1048576

In the man of `libmagic` you find the documentation:

    MAGIC_PARAM_BYTES_MAX        size_t    1048576

So, the `file` command reads while the `MAGIC_PARAM_BYTES_MAX` is reached and closes the file descriptor. 