### PR TITLE
Mention Nix package in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Some package repositories include `mdcat`:
 * [Homebrew]: `brew install mdcat`
 * Arch Linux: `pacman -S mdcat`
 * Void Linux: `xbps-install -S mdcat`
+* Nixpkgs: `nix-env -i mdcat`
 
 [Homebrew]: https://brew.sh
 [aur]: https://aur.archlinux.org/packages/mdcat/


### PR DESCRIPTION
mdcat has [been packaged in nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/text/mdcat/default.nix) for a while (it's being updated to 0.21.1 in https://github.com/NixOS/nixpkgs/pull/97221).