### PR TITLE
Add ureq feature, enabled by default.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,9 @@ jobs:
             os: ubuntu-latest
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            flags: --no-default-features
           - target: x86_64-apple-darwin
             os: macOS-latest
           - target: x86_64-pc-windows-msvc
@@ -97,22 +100,22 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-targets --locked --target ${{ matrix.target }}
+          args: --all-targets --locked --target ${{ matrix.target }} ${{ matrix.flags }}
       # Lint
       - name: Clippy
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets --locked --target ${{ matrix.target }}
+          args: --all-targets --locked --target ${{ matrix.target }} ${{ matrix.flags }}
           name: clippy-${{ matrix.rust}}-${{ matrix.target }}
       # Test
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --locked --target ${{ matrix.target }}
+          args: --locked --target ${{ matrix.target }} ${{ matrix.flags }}
       - name: Format sample
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --target ${{ matrix.target }} -- sample/common-mark.md
+          args: --target ${{ matrix.target }} ${{ matrix.flags }} -- sample/common-mark.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ To publish a new release run `scripts/release` from the project directory.
 
 ## [Unreleased]
 
+### Added
+
+- Add `ureq` cargo feature so mdcat can be built on platforms not supported by
+    ureq's dependencies. Such builds will lack the ability to fetch images.
+
 ## [0.22.2] – 2021-01-01
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ license = "MPL-2.0"
 authors = ["Sebastian Wiesner <sebastian@swsnr.de>"]
 edition = "2018"
 
+[features]
+default = ["ureq"]
+
 [dependencies]
 ansi_term = "^0.12"
 base64 = "^0.13"
@@ -23,7 +26,6 @@ fehler = "^1"
 anyhow = "^1"
 shell-words = "^1"
 env_proxy = "^0.4"
-ureq = { version = "^1.5", features = ["tls", "native-certs"] }
 
 [dependencies.clap]
 version = "^2.33"
@@ -38,6 +40,11 @@ features = ['simd']
 version = "^4.5"
 default-features = false
 features = ["parsing", "assets", "dump-load", "regex-fancy"]
+
+[dependencies.ureq]
+version = "^1.5"
+optional = true
+features = ["tls", "native-certs"]
 
 [target.'cfg(unix)'.dependencies]
 libc = "^0.2"


### PR DESCRIPTION
ureq depends on rustls, which depends on ring, which runs on a limited
set of platforms. By making it possible to disable the ureq feature, we
allow mdcat to be built for platforms not supported by ring, while
maintaining most of its functionality.