### PR TITLE
automatically convert ioctl request parameter

### DIFF
--- a/src/terminal/size.rs
+++ b/src/terminal/size.rs
@@ -105,7 +105,7 @@ fn from_terminal_impl() -> Option<TerminalSize> {
             None
         } else {
             let fd = libc::open(cterm_path, libc::O_RDONLY);
-            let result = libc::ioctl(fd, libc::TIOCGWINSZ, &mut winsize);
+            let result = libc::ioctl(fd, libc::TIOCGWINSZ.into(), &mut winsize);
             libc::close(fd);
             if result == -1 || winsize.ws_row == 0 || winsize.ws_col == 0 {
                 None

--- a/src/terminal/size.rs
+++ b/src/terminal/size.rs
@@ -105,6 +105,10 @@ fn from_terminal_impl() -> Option<TerminalSize> {
             None
         } else {
             let fd = libc::open(cterm_path, libc::O_RDONLY);
+            // disable this check for the ioctl(2) call because different libcs
+            // can have different types for the request parameter, see
+            // https://github.com/lunaryorn/mdcat/issues/177
+            #[allow(clippy:::useless_conversion)]
             let result = libc::ioctl(fd, libc::TIOCGWINSZ.into(), &mut winsize);
             libc::close(fd);
             if result == -1 || winsize.ws_row == 0 || winsize.ws_col == 0 {

--- a/src/terminal/size.rs
+++ b/src/terminal/size.rs
@@ -108,7 +108,7 @@ fn from_terminal_impl() -> Option<TerminalSize> {
             // disable this check for the ioctl(2) call because different libcs
             // can have different types for the request parameter, see
             // https://github.com/lunaryorn/mdcat/issues/177
-            #[allow(clippy:::useless_conversion)]
+            #[allow(clippy::useless_conversion)]
             let result = libc::ioctl(fd, libc::TIOCGWINSZ.into(), &mut winsize);
             libc::close(fd);
             if result == -1 || winsize.ws_row == 0 || winsize.ws_col == 0 {


### PR DESCRIPTION
FreeBSD ioctl(2) takes unsigned long long as request parameter.
Here we automatically convert it with `.into()` to whatever the libc underneath needs

This fixes #177