### PR TITLE
Add support for WezTerm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ To publish a new release run `scripts/release` from the project directory.
 
 ## [Unreleased]
 
+### Added
+- Support for [WezTerm](https://wezfurlong.org/wezterm/) (see [GH-182]).
+
+[GH-182]: https://github.com/lunaryorn/mdcat/pull/182
+
 ## [0.22.4] – 2021-04-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Then it
 | [Terminology][]            | ✓             | ✓                   | ✓     | ✓      |            |
 | [iTerm2][]                 | ✓             | ✓                   | ✓     | ✓ 2)   | ✓          |
 | [kitty][]                  | ✓             | ✓                   | ✓     | ✓ 2)   |            |
+| [WezTerm][]                | ✓             | ✓                   | ✓     | ✓ 2)   |            |
 
 1) VTE is Gnome’s terminal emulation library used by many popular terminal emulators on Linux, including Gnome Terminal, Xfce Terminal, Tilix, etc.
 2) SVG images require `rsvg-convert` from librsvg.
@@ -51,6 +52,7 @@ Not supported:
 [Terminology]: http://terminolo.gy
 [ConEmu]: https://conemu.github.io
 [iterm2]: https://www.iterm2.com
+[WezTerm]: https://wezfurlong.org/wezterm/
 
 ## Usage
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -80,6 +80,11 @@ fn get_vte_version() -> Option<(u8, u8)> {
     })
 }
 
+/// Checks if the current terminal is WezTerm.
+fn is_wezterm() -> bool {
+    std::env::var("TERM").map_or(false, |value| value == "wezterm")
+}
+
 impl TerminalCapabilities {
     /// A terminal which supports nothing.
     pub fn none() -> TerminalCapabilities {
@@ -149,6 +154,23 @@ impl TerminalCapabilities {
         }
     }
 
+    /// Terminal capabilities of WezTerm (Wez's Terminal Emulator).
+    ///
+    /// WezTerm is a GPU-accelerated cross-platform
+    /// terminal emulator and multiplexer written by @wez
+    /// and implemented in Rust.
+    ///
+    /// See <https://wezfurlong.org/wezterm/> for more details.
+    pub fn wezterm() -> TerminalCapabilities {
+        TerminalCapabilities {
+            name: "WezTerm".to_string(),
+            style: Some(StyleCapability::Ansi(AnsiStyle)),
+            links: Some(LinkCapability::Osc8(self::osc::Osc8Links)),
+            image: Some(ImageCapability::ITerm2(self::iterm2::ITerm2Images)),
+            marks: None,
+        }
+    }
+
     /// Detect the capabilities of the current terminal.
     pub fn detect() -> TerminalCapabilities {
         if self::iterm2::is_iterm2() {
@@ -157,6 +179,8 @@ impl TerminalCapabilities {
             Self::terminology()
         } else if self::kitty::is_kitty() {
             Self::kitty()
+        } else if is_wezterm() {
+            Self::wezterm()
         } else if get_vte_version().filter(|&v| v >= (50, 0)).is_some() {
             Self::vte50()
         } else {

--- a/src/terminal/size.rs
+++ b/src/terminal/size.rs
@@ -174,7 +174,7 @@ impl TerminalSize {
     ///
     /// On Windows this uses the [terminal_size] crate which does some magic windows API calls.
     ///
-    /// [term_size]: https://docs.rs/terminal_size/
+    /// [terminal_size]: https://docs.rs/terminal_size/
     pub fn from_terminal() -> Option<Self> {
         from_terminal_impl()
     }


### PR DESCRIPTION
Wez's Terminal Emulator - https://wezfurlong.org/wezterm/

Uses iTerm image protocol for rendering images

---

IMO, terminal specific files in `src/terminal/` dir can be modified to make it as "protocol/features" specific code. And then, we could use `is_term_env_var` function, with slight modification, for detecting other terminals (except VTE). What do you think?

---

Btw, thanks for this cool app! :-)