### PR TITLE
Remove tree_magic_mini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ To publish a new release run `scripts/release` from the project directory.
 - Move repository back to <https://github.com/lunaryorn/mdcat>.
 - Restore release binaries.
 
+### Removed
+- Support for `tree_magic_mini` for mime-type detection; mdcat now only uses the `file` tool (see [GH-204]).
+
+[GH-204]: https://github.com/lunaryorn/mdcat/pull/204
+
 ## [0.28.0] – 2022-07-31
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,12 +87,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
-name = "bytecount"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
-
-[[package]]
 name = "bytemuck"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,12 +318,6 @@ dependencies = [
  "bit-set",
  "regex",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -594,7 +582,6 @@ dependencies = [
  "test-generator",
  "tracing",
  "tracing-subscriber",
- "tree_magic_mini",
  "ureq",
  "url",
 ]
@@ -621,12 +608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,16 +632,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -751,16 +722,6 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
-
-[[package]]
-name = "petgraph"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
 
 [[package]]
 name = "pin-project"
@@ -1324,20 +1285,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "tree_magic_mini"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91adfd0607cacf6e4babdb870e9bec4037c1c4b151cfd279ccefc5e0c7feaa6d"
-dependencies = [
- "bytecount",
- "fnv",
- "lazy_static",
- "nom",
- "once_cell",
- "petgraph",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ license = "MPL-2.0"
 authors = ["Sebastian Wiesner <sebastian@swsnr.de>"]
 edition = "2021"
 
-[features]
-default = ["tree_magic_mini"]
-
 [dependencies]
 ansi_term = "0.12.1"
 anyhow = "1.0.58"
@@ -30,7 +27,6 @@ tracing = { version = "0.1.35", features = ["release_max_level_warn"] }
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 ureq = { version = "2.5.0", features = ["tls", "native-certs"] }
 url = "2.2.2"
-tree_magic_mini = { version = "3.0.3", optional = true }
 
 [dependencies.syntect]
 version = "5.0.0"

--- a/README.md
+++ b/README.md
@@ -74,9 +74,7 @@ Try `mdcat --help` or read the [mdcat(1)](./mdcat.1.adoc) manpage.
 
 ## Requirements
 
-- For image type detection either:
-    - a system-wide [shared mime database](https://www.freedesktop.org/wiki/Specifications/shared-mime-info-spec/), or,
-    - if `mdcat` is built without default features, the `file` tool with support for `--brief` and `--mime-type` flags.
+For image type detection either the `file` tool with support for `--brief` and `--mime-type` flags must be available in `$PATH`.
 
 [Homebrew]: https://brew.sh
 [MacPorts]: https://www.macports.org

--- a/mdcat.1.adoc
+++ b/mdcat.1.adoc
@@ -38,6 +38,8 @@ mdcat supports most standard pixel formats by default.
 
 mdcat silently ignores images larger than 100 MiB.
 
+For some terminals mdcat needs to detect the mimetype; it uses the `file --brief --mime-type` for this purpose, and thus requires a compatible `file` utility in `$PATH`.
+
 === SVG support
 
 In Terminology mdcat also renders SVG images, using the built-in support of Terminology.


### PR DESCRIPTION
It's not exactly well-maintained, has a couple of bugs and obvious programming mistakes, requires a system-wide shared mime database and provides no way to detect the absence of said database.