### PR TITLE
Turn into clap multicall parser

### DIFF
--- a/mdcat.1.adoc
+++ b/mdcat.1.adoc
@@ -21,6 +21,8 @@ mdcat - render CommonMark Markdown to text terminals
 mdcat renders Markdown ``FILE``s in CommonMark dialect to text terminals with sophisticated formatting.
 If no `FILE` is given, or if `FILE` is '-', it reads from standard input.
 
+If invoked as `mdless` automatically use a pager to display the output, see below.
+
 === CommonMark and terminal support
 
 mdcat supports all basic CommonMark syntax plus a few extensions, highlights syntax in code blocks, and shows inline links and even inline images in some terminal emulators.
@@ -30,6 +32,9 @@ In iTerm2 it also adds jump marks for section headings.
 
 mdcat can render output in a pager; this is the default when run as `mdless`.
 The environment variables `$MDCAT_PAGER` and `$PAGER` control the pager used.
+
+Note that common pagers do not support proprietary terminal codes for e.g. image support, so mdcat falls back to pure ANSI formatting when pagination is enabled.
+In particular this disables all image support which relies on proprietary escape codes.
 
 === Image support
 

--- a/src/bin/mdcat/args.rs
+++ b/src/bin/mdcat/args.rs
@@ -4,12 +4,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use clap::{Parser, ValueHint};
+use clap::ValueHint;
 
 fn after_help() -> &'static str {
     "See 'man 1 mdcat' for more information.
 
-Report issues to <https://codeberg.org/flausch/mdcat>."
+Report issues to <https://github.com/lunaryorn/mdcat>."
 }
 
 fn long_version() -> &'static str {
@@ -24,18 +24,68 @@ You can obtain one at http://mozilla.org/MPL/2.0/."
     )
 }
 
-#[derive(Debug, Parser)]
-#[command(author, version, about, after_help = after_help(), long_version = long_version())]
+#[derive(Debug, clap::Parser)]
+#[command(multicall = true)]
 pub struct Args {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum Command {
+    #[command(version, about, after_help = after_help(), long_version = long_version())]
+    Mdcat {
+        #[command(flatten)]
+        args: CommonArgs,
+        /// Paginate the output of mdcat with a pager like less.
+        #[arg(short, long, overrides_with = "no_pager")]
+        paginate: bool,
+        /// Do not paginate output (default). Overrides an earlier --paginate.
+        #[arg(short = 'P', long)]
+        no_pager: bool,
+    },
+    #[command(version, about, after_help = after_help(), long_version = long_version())]
+    Mdless {
+        #[command(flatten)]
+        args: CommonArgs,
+        /// Do not paginate output.
+        #[arg(short = 'P', long, overrides_with = "paginate")]
+        no_pager: bool,
+        /// Paginate the output of mdcat with a pager like less (default). Overrides an earlier --no-pager.
+        #[arg(short, long)]
+        paginate: bool,
+    },
+}
+
+impl Command {
+    #[allow(dead_code)]
+    pub fn paginate(&self) -> bool {
+        match *self {
+            // In both cases look at the option indicating the non-default
+            // behaviour; the overrides above are configured accordingly.
+            Command::Mdcat { paginate, .. } => paginate,
+            Command::Mdless { no_pager, .. } => !no_pager,
+        }
+    }
+}
+
+impl std::ops::Deref for Command {
+    type Target = CommonArgs;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Command::Mdcat { args, .. } => args,
+            Command::Mdless { args, .. } => args,
+        }
+    }
+}
+
+#[derive(Debug, clap::Args)]
+// #[command(author, version, about, after_help = after_help(), long_version = long_version())]
+pub struct CommonArgs {
     /// Files to read.  If - read from standard input instead.
     #[arg(default_value="-", value_hint = ValueHint::FilePath)]
     pub filenames: Vec<String>,
-    /// Paginate the output of mdcat with a pager like less.  Default if invoked as mdless.
-    #[arg(short, long)]
-    pub paginate: bool,
-    /// Do not paginate output. Default if invoked as mdcat.
-    #[arg(short, long, overrides_with = "paginate")]
-    pub no_pager: bool,
     /// Disable all colours and other styles.
     #[arg(short = 'c', long, aliases=["nocolour", "no-color", "nocolor"])]
     pub no_colour: bool,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -39,6 +39,21 @@ mod cli {
     }
 
     #[test]
+    fn long_version_includes_license() {
+        let output = run_cargo_mdcat(["--version"]);
+        let stdout = std::str::from_utf8(&output.stdout).unwrap();
+        assert!(
+            output.status.success(),
+            "non-zero exit code: {:?}",
+            output.status,
+        );
+        assert!(output.stderr.is_empty());
+        assert!(
+            stdout.contains("This program is subject to the terms of the Mozilla Public License,")
+        );
+    }
+
+    #[test]
     fn file_list_fail_late() {
         let output = run_cargo_mdcat(["does-not-exist", "sample/common-mark.md"]);
         let stderr = std::str::from_utf8(&output.stderr).unwrap();


### PR DESCRIPTION
Use clap's multicall feature to model the distinction between mdcat and mdless entirely through clap, instead of checking the executable name manually.