### PR TITLE
Generate completions for each multicall binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,15 @@ To publish a new release run `scripts/release` from the project directory.
 
 ## [Unreleased]
 
+### Added
+- Generate completions for `mdless` (see [GH-216]).
+
 ### Fixed
 - Include generated shell completions in release artifacts.
+- Fix completions for mdcat (see [GH-214] and [GH-216])
+
+[GH-214]: https://github.com/lunaryorn/mdcat/issues/214
+[GH-216]: https://github.com/lunaryorn/mdcat/pull/216
 
 ## [0.29.0] – 2022-10-21
 

--- a/build.rs
+++ b/build.rs
@@ -18,9 +18,12 @@ fn gen_completions<P: AsRef<Path>>(out_dir: P) -> Result<()> {
 
     let completions = out_dir.as_ref().join("completions");
     std::fs::create_dir_all(&completions).expect("Failed to create $OUT_DIR/completions");
-
-    for shell in [Shell::Bash, Shell::Zsh, Shell::Fish, Shell::PowerShell] {
-        generate_to(shell, &mut mdcat::Args::command(), "mdcat", &completions)?;
+    for program in ["mdcat", "mdless"] {
+        for shell in [Shell::Bash, Shell::Zsh, Shell::Fish, Shell::PowerShell] {
+            let mut command = mdcat::Args::command();
+            let subcommand = command.find_subcommand_mut(program).unwrap();
+            generate_to(shell, subcommand, program, &completions)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Fixes completions for `mdcat` and additional generates completions for `mdless`.

Closes GH-214