### PR TITLE
Use libmagic to check mimetypes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,8 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+            # On Linux link against libmagic, since it's almost always available
+            cargo_opts: "--features magic"
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             cargo_opts: "--no-default-features --features static"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ Use `cargo release` to create a new release.
 
 ## [Unreleased]
 
+### Added
+- With `--features magic` use `libmagic` to check for SVG data, instead of shelling out to `file` (see [GH-236]).
+
 ### Changed
 - Update all dependencies.
+
+[GH-236]: https://github.com/swsnr/mdcat/pull/236
 
 ## [1.0.0] – 2023-01-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "magic"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87142e3acb1f4daa62eaea96605421a534119d4777a9fb43fb2784798fd89665"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "magic-sys",
+ "thiserror",
+]
+
+[[package]]
+name = "magic-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff86ae08895140d628119d407d568f3b657145ee8c265878064f717534bb3bc"
+dependencies = [
+ "libc",
+ "vcpkg",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,6 +858,7 @@ dependencies = [
  "image",
  "lazy_static",
  "libc",
+ "magic",
  "mime",
  "once_cell",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,10 @@ authors = ["Sebastian Wiesner <sebastian@swsnr.de>"]
 edition = "2021"
 
 [features]
-default = ["reqwest/native-tls"]
-# For static builds use rustls to avoid cross-building openssl, but use the native certificate roots for
-# maximum compatibility
+default = ["native-tls"]
+native-tls = ["reqwest/native-tls"]
+# For static builds use rustls to avoid cross-building openssl, but use the
+# native certificate roots for maximum compatibility
 static = ["reqwest/rustls-tls-native-roots"]
 
 [dependencies]
@@ -34,6 +35,7 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 url = "2.3.1"
 reqwest = { version = "0.11.14", default-features = false, features = ["gzip", "brotli", "blocking"]}
 once_cell = "1.17.0"
+magic = { version = "0.13.0", optional = true }
 
 [dependencies.syntect]
 version = "5.0.0"

--- a/README.md
+++ b/README.md
@@ -74,9 +74,12 @@ Try `mdcat --help` or read the [mdcat(1)](./mdcat.1.adoc) manpage.
 
 ## Building
 
-Run `cargo build --release`.  The resulting `mdcat` executable links against the system's SSL library, i.e. openssl on Linux.
+Run `cargo build --release`.
+The resulting `mdcat` executable links against the system's SSL library, i.e. openssl on Linux.
 To build a self-contained executable use `cargo build --features=static`; the resulting executable uses a pure Rust SSL implementation.
 It still uses the system's CA roots however.
+
+Pass `--features magic` to use `libmagic` instead of the `file` program to check mimetypes.
 
 The build process also generates the following additional files in `$OUT_DIR`:
 


### PR DESCRIPTION
Add `magic` feature to directly use libmagic instead of calling out to `file`.